### PR TITLE
config cmd

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,9 @@ pub enum StError {
     /// A generic decoding error occurred.
     #[error("Decoding error: {}", .0)]
     DecodingError(String),
+    /// The configuration is not correctly initialized.
+    #[error("Configuration not initialized. Please edit configuration at: {}", .0)]
+    ConfigNotInitialized(String),
 
     // ---- [ `st` application errors (remote) ] ----
     /// A remote pull request could not be found.

--- a/src/subcommands/local/config.rs
+++ b/src/subcommands/local/config.rs
@@ -1,0 +1,34 @@
+//! `status` subcommand.
+
+use crate::constants::ST_CFG_FILE_NAME;
+use crate::{
+    cli::Cli, // Import the Cli struct to access the function
+    ctx::StContext,
+    errors::{StError, StResult},
+};
+use clap::Args;
+use cli_table::{Cell, Style, Table};
+use octocrab::{models::IssueState, Octocrab};
+use std::path::PathBuf;
+
+/// CLI arguments for the `config` subcommand.
+#[derive(Debug, Clone, Eq, PartialEq, Args)]
+pub struct ConfigCmd;
+
+impl ConfigCmd {
+    /// Run the `config` subcommand.
+    pub fn run(self, _ctx: StContext<'_>) -> StResult<()> {
+        let config = Cli::load_cfg_or_initialize()?;
+        let config_path = PathBuf::from(env!("HOME")).join(ST_CFG_FILE_NAME);
+
+        if config.github_token.is_empty() {
+            return Err(StError::ConfigNotInitialized(
+                config_path.display().to_string(),
+            ));
+        } else {
+            println!("Configuration successfully initialized at: {:?}", config_path);
+        }
+
+        Ok(())
+    }
+}

--- a/src/subcommands/local/mod.rs
+++ b/src/subcommands/local/mod.rs
@@ -20,3 +20,6 @@ pub use track::TrackCmd;
 
 mod untrack;
 pub use untrack::UntrackCmd;
+
+mod config;
+pub use config::ConfigCmd;

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -4,7 +4,9 @@ use crate::{ctx::StContext, errors::StResult};
 use clap::Subcommand;
 
 mod local;
-use local::{CheckoutCmd, CreateCmd, DeleteCmd, LogCmd, RestackCmd, TrackCmd, UntrackCmd};
+use local::{
+    CheckoutCmd, ConfigCmd, CreateCmd, DeleteCmd, LogCmd, RestackCmd, TrackCmd, UntrackCmd,
+};
 
 mod remote;
 use remote::{StatusCmd, SubmitCmd, SyncCmd};
@@ -41,6 +43,9 @@ pub enum Subcommands {
     /// Untrack the passed branch.
     #[clap(visible_alias = "ut")]
     Untrack(UntrackCmd),
+    /// Configure the st application.
+    #[clap(visible_alias = "cfg")]
+    Config(ConfigCmd),
 }
 
 impl Subcommands {
@@ -59,6 +64,7 @@ impl Subcommands {
             Self::Log(args) => args.run(ctx),
             Self::Track(args) => args.run(ctx),
             Self::Untrack(args) => args.run(ctx),
+            Self::Config(args) => args.run(ctx),
         }
     }
 }


### PR DESCRIPTION
Added a config command that helps provide more insight into how to configure st. Right now, if st.toml isn't configured correctly it directs the user to open the file by printing the file to the terminal.